### PR TITLE
Add RPM-based distribution support to database setup script

### DIFF
--- a/utilities/linux/databases/LinuxOpaDbSetup.sh
+++ b/utilities/linux/databases/LinuxOpaDbSetup.sh
@@ -3,6 +3,7 @@ set -e
 
 # LinuxOpaDbSetup.sh - Unified PostgreSQL and MySQL setup script
 # Supports auto-detection or explicit database selection
+# Supports Debian/Ubuntu (apt) and RHEL/CentOS/Rocky/Alma (yum/dnf)
 
 # Usage information
 usage() {
@@ -11,6 +12,10 @@ Usage: $0 [OPTIONS]
 
 Setup PostgreSQL or MySQL with OPA orchestrator account.
 The script will use sudo for privileged operations as needed.
+
+Supported distributions:
+  - Debian/Ubuntu (apt-get)
+  - RHEL/CentOS/Rocky/Alma Linux (yum/dnf)
 
 OPTIONS:
     -p                    Install and configure PostgreSQL
@@ -34,14 +39,60 @@ EOF
     exit 1
 }
 
+# Detect Linux distribution type
+detect_distro() {
+    if [[ -f /etc/os-release ]]; then
+        . /etc/os-release
+        echo "$ID"
+    elif [[ -f /etc/redhat-release ]]; then
+        echo "rhel"
+    elif [[ -f /etc/debian_version ]]; then
+        echo "debian"
+    else
+        echo "unknown"
+    fi
+}
+
+# Detect package manager
+detect_package_manager() {
+    local distro=$(detect_distro)
+
+    case "$distro" in
+        ubuntu|debian)
+            echo "apt"
+            ;;
+        rhel|centos|rocky|almalinux|fedora|ol)
+            if command -v dnf >/dev/null 2>&1; then
+                echo "dnf"
+            else
+                echo "yum"
+            fi
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
 # Detect which database is installed
 detect_database() {
     local detected=""
 
-    if command -v psql >/dev/null 2>&1 && systemctl is-active --quiet postgresql 2>/dev/null; then
-        detected="postgres"
-    elif command -v mysql >/dev/null 2>&1 && systemctl is-active --quiet mysql 2>/dev/null; then
-        detected="mysql"
+    # Check PostgreSQL
+    if command -v psql >/dev/null 2>&1; then
+        if systemctl is-active --quiet postgresql 2>/dev/null || \
+           systemctl is-active --quiet postgresql-*.service 2>/dev/null; then
+            detected="postgres"
+        fi
+    fi
+
+    # Check MySQL/MariaDB
+    if [[ -z "$detected" ]] && command -v mysql >/dev/null 2>&1; then
+        if systemctl is-active --quiet mysql 2>/dev/null || \
+           systemctl is-active --quiet mysqld 2>/dev/null || \
+           systemctl is-active --quiet mariadb 2>/dev/null; then
+            detected="mysql"
+        fi
     fi
 
     echo "$detected"
@@ -60,26 +111,108 @@ generate_passwords() {
 
 # Install and configure MySQL
 install_mysql() {
-    echo "Installing MySQL..."
-    sudo apt-get update
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server
+    local pkg_mgr=$(detect_package_manager)
+    echo "Installing MySQL (using $pkg_mgr)..."
+
+    case "$pkg_mgr" in
+        apt)
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server
+            local config_file="/etc/mysql/mysql.conf.d/mysqld.cnf"
+            local service_name="mysql"
+            ;;
+        dnf|yum)
+            sudo $pkg_mgr install -y mysql-server
+            local config_file="/etc/my.cnf.d/mysql-server.cnf"
+            local service_name="mysqld"
+
+            # Enable and start service
+            sudo systemctl enable $service_name
+            sudo systemctl start $service_name
+            ;;
+        *)
+            echo "ERROR: Unsupported package manager: $pkg_mgr"
+            exit 1
+            ;;
+    esac
 
     # Configure MySQL to listen on all interfaces
-    sudo sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
-    sudo systemctl restart mysql
+    if [[ -f "$config_file" ]]; then
+        if grep -q "^bind-address" "$config_file"; then
+            sudo sed -i "s/^bind-address.*/bind-address = 0.0.0.0/" "$config_file"
+        else
+            echo "bind-address = 0.0.0.0" | sudo tee -a "$config_file" >/dev/null
+        fi
+    else
+        echo "[mysqld]" | sudo tee "$config_file" >/dev/null
+        echo "bind-address = 0.0.0.0" | sudo tee -a "$config_file" >/dev/null
+    fi
+
+    sudo systemctl restart $service_name
+    echo "MySQL installation and configuration complete."
 }
 
 # Install and configure PostgreSQL
 install_postgres() {
-    echo "Installing PostgreSQL..."
-    sudo apt-get update
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql postgresql-contrib
+    local pkg_mgr=$(detect_package_manager)
+    echo "Installing PostgreSQL (using $pkg_mgr)..."
 
-    # Configure PostgreSQL to listen on all interfaces
-    sudo bash -c "echo \"listen_addresses = '*'\" >> /etc/postgresql/16/main/postgresql.conf"
-    sudo bash -c "echo \"host    all             all             0.0.0.0/0               md5\" >> /etc/postgresql/16/main/pg_hba.conf"
+    case "$pkg_mgr" in
+        apt)
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql postgresql-contrib
 
-    sudo systemctl restart postgresql
+            # Find PostgreSQL version directory
+            local pg_version=$(ls /etc/postgresql/ | sort -V | tail -1)
+            local config_dir="/etc/postgresql/$pg_version/main"
+            local service_name="postgresql"
+            ;;
+        dnf|yum)
+            sudo $pkg_mgr install -y postgresql-server postgresql-contrib
+
+            # Initialize database if not already initialized
+            if [[ ! -d /var/lib/pgsql/data/base ]]; then
+                echo "Initializing PostgreSQL database..."
+                sudo postgresql-setup --initdb || sudo /usr/bin/postgresql-setup initdb
+            fi
+
+            # Find config directory
+            local pg_version=$(psql --version | awk '{print $3}' | cut -d. -f1)
+            if [[ -d "/var/lib/pgsql/$pg_version/data" ]]; then
+                local config_dir="/var/lib/pgsql/$pg_version/data"
+            else
+                local config_dir="/var/lib/pgsql/data"
+            fi
+            local service_name="postgresql"
+
+            # Enable and start service
+            sudo systemctl enable $service_name
+            sudo systemctl start $service_name
+            ;;
+        *)
+            echo "ERROR: Unsupported package manager: $pkg_mgr"
+            exit 1
+            ;;
+    esac
+
+    echo "Configuring PostgreSQL to listen on all interfaces..."
+
+    # Configure listen_addresses
+    local conf_file="$config_dir/postgresql.conf"
+    if sudo grep -q "^listen_addresses" "$conf_file"; then
+        sudo sed -i "s/^listen_addresses.*/listen_addresses = '*'/" "$conf_file"
+    else
+        echo "listen_addresses = '*'" | sudo tee -a "$conf_file" >/dev/null
+    fi
+
+    # Configure pg_hba.conf for remote access
+    local hba_file="$config_dir/pg_hba.conf"
+    if ! sudo grep -q "0.0.0.0/0" "$hba_file"; then
+        echo "host    all             all             0.0.0.0/0               md5" | sudo tee -a "$hba_file" >/dev/null
+    fi
+
+    sudo systemctl restart $service_name
+    echo "PostgreSQL installation and configuration complete."
 }
 
 # Create MySQL users

--- a/utilities/linux/databases/README.md
+++ b/utilities/linux/databases/README.md
@@ -8,7 +8,8 @@
 
 ## Key Features
 
-- **Auto-detection**: Automatically detects installed database (PostgreSQL or MySQL)
+- **Multi-distribution support**: Works on Debian/Ubuntu (apt) and RHEL/CentOS/Rocky/Alma Linux (yum/dnf)
+- **Auto-detection**: Automatically detects installed database (PostgreSQL or MySQL/MariaDB)
 - **Flexible installation**: Explicit database selection with `-p` (PostgreSQL) or `-m` (MySQL)
 - **Orchestrator account**: Creates `orchestrator_integration_user` with configurable privileges
 - **Example users**: Optional creation of 5 example user accounts with different privilege levels
@@ -16,12 +17,27 @@
 - **Secure credentials**: Generates random passwords and stores them in `/root/`
 - **Network ready**: Configures databases to accept remote connections
 
+## Supported Operating Systems
+
+### Debian-based
+- Ubuntu 20.04, 22.04, 24.04
+- Debian 10, 11, 12
+
+### RPM-based
+- RHEL 8, 9
+- CentOS 8, 9 (Stream)
+- Rocky Linux 8, 9
+- AlmaLinux 8, 9
+- Oracle Linux 8, 9
+- Fedora (recent versions)
+
 ## Prerequisites
 
-- Ubuntu/Debian Linux system
+- Supported Linux distribution (see above)
 - Root or sudo access
 - `openssl` for password generation
 - Internet access for package installation
+- `systemd` for service management
 
 ## Usage
 
@@ -152,24 +168,41 @@ The script is designed to be re-run safely:
 
 ## What the Script Does
 
-1. **Database Installation** (if not already installed)
-   - Installs PostgreSQL or MySQL using apt-get
-   - Configures for remote access
+1. **Distribution Detection**
+   - Automatically detects Linux distribution (Debian/Ubuntu vs RHEL/CentOS/Rocky/Alma)
+   - Selects appropriate package manager (apt, yum, or dnf)
+   - Adapts configuration paths based on distribution
 
-2. **Orchestrator Account Setup**
+2. **Database Installation** (if not already installed)
+   - **Debian/Ubuntu**: Installs using `apt-get`, service name `mysql`/`postgresql`
+   - **RHEL/CentOS/Rocky/Alma**: Installs using `yum`/`dnf`, runs PostgreSQL `initdb` if needed
+   - Configures for remote access with distribution-specific config paths
+
+3. **Orchestrator Account Setup**
    - Creates or updates `orchestrator_integration_user`
    - Grants appropriate privileges based on `-s` flag
    - Sets secure random password on creation
 
-3. **Example Users** (if `-e` flag is used)
+4. **Example Users** (if `-e` flag is used)
    - Creates 5 example accounts with different privilege levels
    - Assigns unique random passwords
    - Configures appropriate database permissions
 
-4. **Credential Management**
+5. **Credential Management**
    - Generates secure random passwords
    - Saves credentials to `/root/` with restricted permissions
    - Backs up existing credential files
+
+## Distribution-Specific Details
+
+### PostgreSQL
+- **Debian/Ubuntu**: Config in `/etc/postgresql/[version]/main/`
+- **RHEL/Rocky/Alma**: Config in `/var/lib/pgsql/data/` or `/var/lib/pgsql/[version]/data/`
+- **RPM systems**: Requires database initialization on first install
+
+### MySQL
+- **Debian/Ubuntu**: Service name `mysql`, config in `/etc/mysql/mysql.conf.d/mysqld.cnf`
+- **RHEL/Rocky/Alma**: Service name `mysqld`, config in `/etc/my.cnf.d/mysql-server.cnf`
 
 ## Troubleshooting
 
@@ -179,13 +212,23 @@ The script is designed to be re-run safely:
 ### Permission denied errors
 - Run with `sudo` or as root user
 
+### Unsupported distribution error
+- Ensure you're running on a supported Debian or RPM-based distribution
+- Check `/etc/os-release` for distribution information
+
 ### Service not active
-- Check service status: `systemctl status postgresql` or `systemctl status mysql`
-- Restart service: `sudo systemctl restart postgresql` or `sudo systemctl restart mysql`
+**Debian/Ubuntu:**
+- PostgreSQL: `systemctl status postgresql`
+- MySQL: `systemctl status mysql`
+
+**RHEL/Rocky/Alma:**
+- PostgreSQL: `systemctl status postgresql`
+- MySQL: `systemctl status mysqld`
 
 ### Cannot connect remotely
 - Verify firewall rules allow database ports (5432 for PostgreSQL, 3306 for MySQL)
-- Check database configuration files for network settings
+- **RPM-based systems**: Configure firewall with `firewall-cmd --add-service=postgresql --permanent` or `firewall-cmd --add-port=3306/tcp --permanent`
+- Check database configuration files for network settings (paths vary by distribution)
 
 ## Security Considerations
 
@@ -198,7 +241,7 @@ The script is designed to be re-run safely:
 ## Download and Run
 
 ```bash
-curl -O https://raw.githubusercontent.com/Okta-PAM-Resource-Kit/scripts/main/utilities/databases/LinuxOpaDbSetup.sh
+curl -O https://raw.githubusercontent.com/Okta-PAM-Resource-Kit/scripts/main/utilities/linux/databases/LinuxOpaDbSetup.sh
 chmod +x LinuxOpaDbSetup.sh
 ./LinuxOpaDbSetup.sh -p -e  # Example: PostgreSQL with example users
 ```
@@ -209,5 +252,5 @@ Shad Lutz
 
 ## Related Scripts
 
-- [Linux Universal OPA Install](../../installation/linux/README.md) - Agent installation
-- [Linux AD Join](../linux/ad_domain_join/README.md) - Active Directory integration
+- [Linux Universal OPA Install](../../../installation/linux/README.md) - Agent installation
+- [Linux AD Join](../ad_domain_join/README.md) - Active Directory integration


### PR DESCRIPTION
## Summary
Extended `LinuxOpaDbSetup.sh` to support both Debian-based and RPM-based Linux distributions.

## Changes

### Script Enhancements
- **Multi-distribution detection**: Added `detect_distro()` and `detect_package_manager()` functions
- **Package manager support**: Now handles apt (Debian/Ubuntu), yum, and dnf (RHEL/CentOS/Rocky/Alma)
- **PostgreSQL improvements**:
  - Auto-detects PostgreSQL version and config directory
  - Runs `initdb` on RPM systems if needed
  - Handles different config paths: `/etc/postgresql/*/main/` (Debian) vs `/var/lib/pgsql/data/` (RPM)
- **MySQL improvements**:
  - Supports different service names: `mysql` (Debian) vs `mysqld` (RPM)
  - Handles different config paths: `/etc/mysql/mysql.conf.d/` vs `/etc/my.cnf.d/`
- **Service detection**: Enhanced `detect_database()` to check multiple service names

### Documentation Updates
- Added supported distributions list (Ubuntu, Debian, RHEL, CentOS, Rocky, Alma, Oracle Linux, Fedora)
- Documented distribution-specific differences
- Updated troubleshooting section with RPM-specific guidance
- Added firewall configuration notes for RPM systems

### File Organization
- Moved files to correct location: `utilities/linux/databases/` (was `utilities/databases/`)

## Supported Distributions

### Debian-based
- Ubuntu 20.04, 22.04, 24.04
- Debian 10, 11, 12

### RPM-based  
- RHEL 8, 9
- CentOS 8, 9 (Stream)
- Rocky Linux 8, 9
- AlmaLinux 8, 9
- Oracle Linux 8, 9
- Fedora (recent versions)

## Test plan
- [x] Script syntax validation (`bash -n`)
- [ ] Test on Ubuntu 24.04 with PostgreSQL
- [ ] Test on Rocky Linux 9 with PostgreSQL
- [ ] Test on Ubuntu 24.04 with MySQL
- [ ] Test on Rocky Linux 9 with MySQL
- [ ] Verify idempotent behavior on both distro families
- [ ] Verify auto-detection on both distro families

🤖 Generated with [Claude Code](https://claude.com/claude-code)