### PR TITLE
Fix bash regex syntax error for Ubuntu 24.04

### DIFF
--- a/utilities/linux/databases/LinuxOpaDbSetup.sh
+++ b/utilities/linux/databases/LinuxOpaDbSetup.sh
@@ -116,7 +116,7 @@ detect_postgres_version() {
         version_string=$(psql --version 2>/dev/null | head -1)
         if [[ $version_string =~ ([0-9]+)\.([0-9]+) ]]; then
             major_version="${BASH_REMATCH[1]}"
-        elif [[ $version_string =~ ([0-9]+)\ ]]; then
+        elif [[ $version_string =~ ([0-9]+)[[:space:]] ]]; then
             # PostgreSQL 10+ uses single number versioning
             major_version="${BASH_REMATCH[1]}"
         fi


### PR DESCRIPTION
## Summary
- Fixed syntax error in PostgreSQL version detection regex that fails on Ubuntu 24.04
- Replaced escaped space `\ ` with `[[:space:]]` character class for better bash compatibility

## Test plan
- [x] Tested on Ubuntu 24.04 - script now runs without syntax errors
- [x] Verified PostgreSQL version detection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)