### PR TITLE
Add session log converter service with cloud storage mounting

### DIFF
--- a/utilities/session_recordings/cloud_storage/README.md
+++ b/utilities/session_recordings/cloud_storage/README.md
@@ -1,0 +1,354 @@
+# Session Log Converter Service
+
+**DISCLAIMER:** This is an unsupported, experimental project. It is not intended for production use.
+
+Watches for new OPA session logs and converts them to asciinema (SSH) or MKV (RDP) format, saving to a mounted cloud storage bucket.
+
+## Prerequisites
+
+- `inotify-tools` package installed
+- `sft` CLI installed and configured
+- Cloud storage bucket mounted locally (see below)
+
+## Installation
+
+1. Copy the script to `/etc/sft/`:
+   ```bash
+   sudo cp cloud_convertlogs.sh /etc/sft/cloud_convertlogs.sh
+   sudo chmod +x /etc/sft/cloud_convertlogs.sh
+   ```
+
+2. Create the systemd service file at `/etc/systemd/system/session-log-converter.service`:
+   ```ini
+   [Unit]
+   Description=Watch for new OPA session logs and convert them
+   After=network-online.target
+   Wants=network-online.target
+
+   [Service]
+   Type=simple
+   ExecStart=/etc/sft/cloud_convertlogs.sh
+   Restart=always
+   RestartSec=5s
+   Environment="WATCHPATH=/var/log/sft/sessions"
+   Environment="DESTPATH=/mnt/cloud/sessions"
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+3. Enable and start the service:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable session-log-converter
+   sudo systemctl start session-log-converter
+   ```
+
+4. Check status:
+   ```bash
+   sudo systemctl status session-log-converter
+   sudo journalctl -u session-log-converter -f
+   ```
+
+## Mounting Cloud Storage
+
+Choose one of the following options to mount cloud storage as a local filesystem.
+
+### AWS S3 (using s3fs)
+
+1. Install s3fs:
+   ```bash
+   sudo apt-get install s3fs
+   ```
+
+2. Create mount point:
+   ```bash
+   sudo mkdir -p /mnt/cloud/sessions
+   ```
+
+3. Configure authentication (choose one):
+
+   **Option A: EC2 Instance Profile (recommended for EC2 instances)**
+   
+   Attach an IAM role to your EC2 instance with S3 access permissions. No additional configuration needed - s3fs will automatically use the instance metadata service.
+   
+   ```bash
+   sudo s3fs your-bucket-name /mnt/cloud/sessions \
+       -o iam_role=auto \
+       -o allow_other \
+       -o use_path_request_style \
+       -o url=https://s3.amazonaws.com
+   ```
+   
+   For persistent mount, add to `/etc/fstab`:
+   ```
+   your-bucket-name /mnt/cloud/sessions fuse.s3fs _netdev,allow_other,iam_role=auto 0 0
+   ```
+
+   **Option B: IAM Roles Anywhere (recommended for non-AWS environments)**
+   
+   [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) allows workloads outside of AWS to use X.509 certificates to obtain temporary credentials.
+   
+   1. Set up a trust anchor and profile in IAM Roles Anywhere
+   2. Install the credential helper:
+      ```bash
+      wget https://rolesanywhere.amazonaws.com/releases/1.0.5/X86_64/Linux/aws_signing_helper
+      chmod +x aws_signing_helper
+      sudo mv aws_signing_helper /usr/local/bin/
+      ```
+   3. Configure credential process in `~/.aws/config`:
+      ```ini
+      [profile rolesanywhere]
+      credential_process = /usr/local/bin/aws_signing_helper credential-process \
+          --certificate /path/to/certificate.pem \
+          --private-key /path/to/private-key.pem \
+          --trust-anchor-arn arn:aws:rolesanywhere:REGION:ACCOUNT:trust-anchor/TRUST_ANCHOR_ID \
+          --profile-arn arn:aws:rolesanywhere:REGION:ACCOUNT:profile/PROFILE_ID \
+          --role-arn arn:aws:iam::ACCOUNT:role/ROLE_NAME
+      ```
+   4. Mount using the profile:
+      ```bash
+      AWS_PROFILE=rolesanywhere sudo -E s3fs your-bucket-name /mnt/cloud/sessions \
+          -o allow_other \
+          -o use_path_request_style \
+          -o url=https://s3.amazonaws.com
+      ```
+
+   **Option C: Static credentials (last resort)**
+   
+   Only use if instance profiles and Roles Anywhere are not available.
+   
+   ```bash
+   echo "ACCESS_KEY_ID:SECRET_ACCESS_KEY" > /root/.passwd-s3fs
+   chmod 600 /root/.passwd-s3fs
+   
+   sudo s3fs your-bucket-name /mnt/cloud/sessions \
+       -o passwd_file=/root/.passwd-s3fs \
+       -o allow_other \
+       -o use_path_request_style \
+       -o url=https://s3.amazonaws.com
+   ```
+   
+   For persistent mount, add to `/etc/fstab`:
+   ```
+   your-bucket-name /mnt/cloud/sessions fuse.s3fs _netdev,allow_other,passwd_file=/root/.passwd-s3fs 0 0
+   ```
+
+### Google Cloud Storage (using gcsfuse)
+
+1. Install gcsfuse:
+   ```bash
+   export GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s)
+   echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+   sudo apt-get update
+   sudo apt-get install gcsfuse
+   ```
+
+2. Create mount point:
+   ```bash
+   sudo mkdir -p /mnt/cloud/sessions
+   ```
+
+3. Configure authentication (choose one):
+
+   **Option A: VM Service Account (recommended for GCE instances)**
+   
+   Attach a service account to your Compute Engine instance with Storage Object Admin permissions on the bucket. No additional configuration needed - gcsfuse will automatically use the instance metadata service.
+   
+   ```bash
+   gcsfuse your-bucket-name /mnt/cloud/sessions
+   ```
+   
+   For persistent mount, add to `/etc/fstab`:
+   ```
+   your-bucket-name /mnt/cloud/sessions gcsfuse rw,_netdev,allow_other,file_mode=644,dir_mode=755 0 0
+   ```
+
+   **Option B: Workload Identity Federation (recommended for non-GCP environments)**
+   
+   [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) allows external workloads to authenticate using OIDC/SAML tokens from external identity providers.
+   
+   1. Create a workload identity pool and provider in GCP
+   2. Grant the external identity access to a service account with Storage permissions
+   3. Download the credential configuration file
+   4. Set the environment variable and mount:
+      ```bash
+      export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential-config.json
+      gcsfuse your-bucket-name /mnt/cloud/sessions
+      ```
+   
+   For persistent mount with systemd, create a service that sets the environment variable, or add to `/etc/environment`:
+   ```
+   GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential-config.json
+   ```
+
+   **Option C: Service Account Key (last resort)**
+   
+   Only use if VM service accounts and Workload Identity Federation are not available.
+   
+   1. Create a service account and download the JSON key file
+   2. Set permissions and mount:
+      ```bash
+      sudo mkdir -p /etc/gcsfuse
+      sudo mv service-account-key.json /etc/gcsfuse/
+      sudo chmod 600 /etc/gcsfuse/service-account-key.json
+      
+      GOOGLE_APPLICATION_CREDENTIALS=/etc/gcsfuse/service-account-key.json \
+          gcsfuse your-bucket-name /mnt/cloud/sessions
+      ```
+   
+   For persistent mount, add to `/etc/fstab`:
+   ```
+   your-bucket-name /mnt/cloud/sessions gcsfuse rw,_netdev,allow_other,key_file=/etc/gcsfuse/service-account-key.json 0 0
+   ```
+
+### Azure Blob Storage (using blobfuse2)
+
+1. Install blobfuse2:
+   ```bash
+   sudo apt-get install libfuse3-dev fuse3
+   wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+   sudo dpkg -i packages-microsoft-prod.deb
+   sudo apt-get update
+   sudo apt-get install blobfuse2
+   ```
+
+2. Create cache and mount directories:
+   ```bash
+   sudo mkdir -p /tmp/blobfuse2cache
+   sudo mkdir -p /mnt/cloud/sessions
+   ```
+
+3. Configure authentication (choose one):
+
+   **Option A: Managed Identity (recommended for Azure VMs)**
+   
+   Assign a managed identity to your Azure VM and grant it Storage Blob Data Contributor role on the storage account.
+   
+   Create config file at `/etc/blobfuse2/config.yaml`:
+   ```yaml
+   allow-other: true
+   logging:
+     type: syslog
+     level: log_warning
+   components:
+     - libfuse
+     - file_cache
+     - attr_cache
+     - azstorage
+   libfuse:
+     attribute-expiration-sec: 120
+     entry-expiration-sec: 120
+   file_cache:
+     path: /tmp/blobfuse2cache
+     timeout-sec: 120
+   attr_cache:
+     timeout-sec: 7200
+   azstorage:
+     type: block
+     account-name: your-storage-account
+     container: your-container-name
+     mode: msi
+   ```
+   
+   Mount the container:
+   ```bash
+   sudo blobfuse2 mount /mnt/cloud/sessions --config-file=/etc/blobfuse2/config.yaml
+   ```
+   
+   For persistent mount, add to `/etc/fstab`:
+   ```
+   /mnt/cloud/sessions fuse blobfuse2,config-file=/etc/blobfuse2/config.yaml,_netdev 0 0
+   ```
+
+   **Option B: Workload Identity Federation (recommended for non-Azure environments)**
+   
+   [Workload Identity Federation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation) allows external applications to authenticate using federated credentials from external identity providers.
+   
+   1. Register an application in Microsoft Entra ID
+   2. Configure federated credentials for your external identity provider
+   3. Grant the application Storage Blob Data Contributor role on the storage account
+   4. Create config file at `/etc/blobfuse2/config.yaml`:
+      ```yaml
+      allow-other: true
+      logging:
+        type: syslog
+        level: log_warning
+      components:
+        - libfuse
+        - file_cache
+        - attr_cache
+        - azstorage
+      libfuse:
+        attribute-expiration-sec: 120
+        entry-expiration-sec: 120
+      file_cache:
+        path: /tmp/blobfuse2cache
+        timeout-sec: 120
+      attr_cache:
+        timeout-sec: 7200
+      azstorage:
+        type: block
+        account-name: your-storage-account
+        container: your-container-name
+        mode: spn
+        appid: your-application-client-id
+        tenantid: your-tenant-id
+        oauth-token-path: /path/to/federated-token
+      ```
+   5. Mount the container:
+      ```bash
+      sudo blobfuse2 mount /mnt/cloud/sessions --config-file=/etc/blobfuse2/config.yaml
+      ```
+
+   **Option C: Storage Account Key (last resort)**
+   
+   Only use if managed identities and Workload Identity Federation are not available.
+   
+   Create config file at `/etc/blobfuse2/config.yaml`:
+   ```yaml
+   allow-other: true
+   logging:
+     type: syslog
+     level: log_warning
+   components:
+     - libfuse
+     - file_cache
+     - attr_cache
+     - azstorage
+   libfuse:
+     attribute-expiration-sec: 120
+     entry-expiration-sec: 120
+   file_cache:
+     path: /tmp/blobfuse2cache
+     timeout-sec: 120
+   attr_cache:
+     timeout-sec: 7200
+   azstorage:
+     type: block
+     account-name: your-storage-account
+     account-key: your-storage-account-key
+     container: your-container-name
+     endpoint: https://your-storage-account.blob.core.windows.net
+   ```
+   
+   Secure and mount:
+   ```bash
+   sudo chmod 600 /etc/blobfuse2/config.yaml
+   sudo blobfuse2 mount /mnt/cloud/sessions --config-file=/etc/blobfuse2/config.yaml
+   ```
+   
+   For persistent mount, add to `/etc/fstab`:
+   ```
+   /mnt/cloud/sessions fuse blobfuse2,config-file=/etc/blobfuse2/config.yaml,_netdev 0 0
+   ```
+
+## Configuration
+
+The script uses environment variables that can be set in the systemd service file:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WATCHPATH` | `/var/log/sft/sessions` | Directory to watch for new session logs |
+| `DESTPATH` | `/mnt/cloud/sessions` | Destination for converted files |

--- a/utilities/session_recordings/cloud_storage/cloud_convertlogs.sh
+++ b/utilities/session_recordings/cloud_storage/cloud_convertlogs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Watch for new session logs and convert them to asciinema (ssh) and mkv (rdp).
+# Intended to run as a systemd service.
+
+set -euo pipefail
+
+WATCHPATH="${WATCHPATH:-/var/log/sft/sessions}"
+DESTPATH="${DESTPATH:-/mnt/cloud/sessions}"
+
+process_logs_ssh() {
+    local file="$1"
+    sft session-logs export --insecure --format asciinema \
+        --output "$DESTPATH/${file}.cast" "$WATCHPATH/$file"
+}
+
+process_logs_rdp() {
+    local file="$1"
+    sft session-logs export --insecure --format mkv \
+        --output "$DESTPATH" "$WATCHPATH/$file"
+}
+
+if [[ ! -d "$WATCHPATH" ]]; then
+    echo "Error: Watch path $WATCHPATH does not exist" >&2
+    exit 1
+fi
+
+if [[ ! -d "$DESTPATH" ]]; then
+    echo "Error: Destination path $DESTPATH does not exist" >&2
+    exit 1
+fi
+
+echo "Watching $WATCHPATH for new session logs..."
+echo "Converted files will be written to $DESTPATH"
+
+inotifywait -m "$WATCHPATH" -e create 2>/dev/null |
+while read -r dirpath action file; do
+    if [[ $file == *ssh~* ]]; then
+        echo "SSH session capture found: $file"
+        if process_logs_ssh "$file"; then
+            echo "SSH session converted successfully"
+        else
+            echo "Error converting SSH session: $file" >&2
+        fi
+    elif [[ $file == *rdp~* ]]; then
+        echo "RDP session capture found: $file"
+        if process_logs_rdp "$file"; then
+            echo "RDP session converted successfully"
+        else
+            echo "Error converting RDP session: $file" >&2
+        fi
+    else
+        echo "Skipping unknown file type: $file"
+    fi
+done


### PR DESCRIPTION
## Summary
- Add script to watch OPA session logs and convert to asciinema (SSH) and MKV (RDP) formats
- Add systemd service configuration for running as a Linux service
- Add comprehensive cloud storage mounting instructions for AWS S3, GCS, and Azure Blob
- Document three authentication options per provider: instance-attached identities, workload identity federation, and static credentials

## Test plan
- [ ] Verify script runs with `inotifywait` watching the session directory
- [ ] Test SSH session conversion to `.cast` format
- [ ] Test RDP session conversion to `.mkv` format
- [ ] Validate systemd service starts and restarts correctly
- [ ] Test cloud storage mount with chosen provider and authentication method

🤖 Generated with [Claude Code](https://claude.com/claude-code)