### PR TITLE
Fix create-shortcuts command for module context

### DIFF
--- a/utilities/sft_wrappers/SftRunAs/Public/Invoke-SftRunAs.ps1
+++ b/utilities/sft_wrappers/SftRunAs/Public/Invoke-SftRunAs.ps1
@@ -189,7 +189,6 @@ Special Commands:
     }
     $account = $Tool
     $desktopPath = [System.Environment]::GetFolderPath('Desktop')
-    $scriptPath = $MyInvocation.MyCommand.Path
     $wshShell = New-Object -ComObject WScript.Shell
 
     Write-Host "Creating shortcuts on your desktop for account '$account'..." -ForegroundColor Cyan
@@ -203,9 +202,9 @@ Special Commands:
       $psExe = Get-Command pwsh
       $shortcut = $wshShell.CreateShortcut($shortcutPath)
       $shortcut.TargetPath = $psExe.Source
-      $shortcut.Arguments = "-NoProfile -File `"$scriptPath`" -RunAs '$account' -Tool '$toolName'"
+      $shortcut.Arguments = "-NoProfile -Command `"Import-Module SftRunAs; sft-runas '$account' '$toolName'`""
       $shortcut.Description = "Run $toolName as $account via Okta Privileged Access"
-      
+
       if ($toolInfo.File -eq $mmc) {
         $shortcut.IconLocation = $toolInfo.Args[0] # .msc file
       } else {


### PR DESCRIPTION
## Summary
- Fix error: "The property 'Path' cannot be found on this object"
- `$MyInvocation.MyCommand.Path` doesn't exist for module functions
- Changed shortcuts to call `Import-Module SftRunAs; sft-runas` directly

## Test plan
- [ ] Run `sft-runas create-shortcuts user@domain.com`
- [ ] Verify shortcuts are created on desktop
- [ ] Click a shortcut to verify it launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)