### PR TITLE
Change shortcut name format

### DIFF
--- a/utilities/sft_wrappers/SftRunAs/Public/Invoke-SftRunAs.ps1
+++ b/utilities/sft_wrappers/SftRunAs/Public/Invoke-SftRunAs.ps1
@@ -197,7 +197,7 @@ Special Commands:
     foreach ($preset in $Presets.GetEnumerator() | Sort-Object Name) {
       $toolName = $preset.Name
       $toolInfo = $preset.Value
-      $shortcutName = "SftRunAs - $toolName"
+      $shortcutName = "$toolName (SftRunAs)"
       $shortcutPath = Join-Path $desktopPath "$shortcutName.lnk"
 
       $psExe = Get-Command pwsh


### PR DESCRIPTION
## Summary
- Change shortcut naming from `SftRunAs - toolname` to `toolname (SftRunAs)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)