### PR TITLE
Add sft version check requiring v1.101.2 or later

### DIFF
--- a/utilities/sft_wrappers/SftRunAs/Public/Invoke-SftRunAs.ps1
+++ b/utilities/sft_wrappers/SftRunAs/Public/Invoke-SftRunAs.ps1
@@ -64,6 +64,18 @@ Special Commands:
     }
   }
 
+  function Require-SftVersion([version]$MinVersion) {
+    $versionOutput = & sft version 2>&1
+    if ($versionOutput -match 'Version:\s*(\d+\.\d+\.\d+)') {
+      $currentVersion = [version]$Matches[1]
+      if ($currentVersion -lt $MinVersion) {
+        throw "sft version $currentVersion is installed, but version $MinVersion or later is required. Please update the Okta Privileged Access client."
+      }
+    } else {
+      Write-Host "Warning: Could not determine sft version. Minimum required: $MinVersion" -ForegroundColor Yellow
+    }
+  }
+
   function Parse-Identity([string]$IdentityString) {
     if ($IdentityString -match '^(?<usr>[^@]+)@(?<dom>.+)$') {
       return [pscustomobject]@{ User=$Matches.usr; UPN=$Matches.dom; Raw=$IdentityString }
@@ -287,6 +299,7 @@ Special Commands:
 
   if ($RunAs.ToLowerInvariant() -eq "doctor") {
     Require-Command "sft"
+    Require-SftVersion "1.101.2"
 
     Write-Host "Environment" -ForegroundColor Cyan
     Write-Host "  sft path:        $((Get-Command sft).Source)"
@@ -355,7 +368,8 @@ Special Commands:
 
   # Main execution
   Require-Command "sft"
-  
+  Require-SftVersion "1.101.2"
+
   Write-Host "Attempting to run '$Tool' as '$RunAs'..." -ForegroundColor Cyan
 
   $id = Parse-Identity -IdentityString $RunAs

--- a/utilities/sft_wrappers/SftRunAs/README.md
+++ b/utilities/sft_wrappers/SftRunAs/README.md
@@ -29,7 +29,7 @@ No passwords are stored on disk. Credentials are retrieved at runtime, used to c
 ### Required
 
 - Windows 10/11 **Pro, Enterprise, or Education**
-- Okta Privileged Access client (`sft`) installed and enrolled
+- Okta Privileged Access client (`sft`) **v1.101.2 or later**, installed and enrolled
 - Access to an OPA-managed **Active Directory account**
 - PowerShell 5.1 or later (PowerShell 7+ supported)
 


### PR DESCRIPTION
## Summary
- Add `Require-SftVersion` function to validate sft client version
- Check version in doctor command and main execution
- Update README to document minimum version requirement (v1.101.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)