### PR TITLE
Add Unblock-File command to download instructions

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/README.md
+++ b/diagnostics/AD_Pwd_Tracking/README.md
@@ -55,6 +55,9 @@ curl -o "$modulePath\Public\Get-OpaAdAccounts.ps1" "$baseUrl/Public/Get-OpaAdAcc
 curl -o "$modulePath\Public\Get-AdPasswordHistory.ps1" "$baseUrl/Public/Get-AdPasswordHistory.ps1"
 curl -o "$modulePath\Public\Compare-OpaAdRotations.ps1" "$baseUrl/Public/Compare-OpaAdRotations.ps1"
 curl -o "$modulePath\Public\Export-RotationReport.ps1" "$baseUrl/Public/Export-RotationReport.ps1"
+
+# Unblock downloaded files (required for files downloaded from the internet)
+Get-ChildItem -Path $modulePath -Recurse | Unblock-File
 ```
 
 ### Import and Run


### PR DESCRIPTION
## Summary
- Add `Unblock-File` command after downloading module files
- Files downloaded from the internet are blocked by Windows and won't load without unblocking

## Test plan
- [ ] Download module using instructions
- [ ] Verify `Import-Module` works without security warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)