### PR TITLE
Add progress feedback and timeouts to API calls

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Get-OpaCredential.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Get-OpaCredential.ps1
@@ -45,6 +45,7 @@ function Get-OpaCredential {
         try {
             $null = cmdkey /delete:$script:CredentialTarget 2>&1
             $null = cmdkey /generic:$script:CredentialTarget /user:$keyId /pass:$keySecret
+            Write-Host "Credentials stored in Windows Credential Manager." -ForegroundColor Green
             Write-Verbose "Credentials stored in Windows Credential Manager"
         }
         catch {

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Invoke-OpaApiRequest.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Invoke-OpaApiRequest.ps1
@@ -29,15 +29,21 @@ function Get-OpaToken {
     } | ConvertTo-Json
 
     Write-Verbose "Requesting new bearer token from $tokenUrl"
+    Write-Host "Authenticating to OPA API..." -ForegroundColor Yellow
 
     try {
-        $response = Invoke-RestMethod -Uri $tokenUrl -Method Post -Body $body -ContentType 'application/json'
+        # Ensure TLS 1.2 is enabled
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+        $response = Invoke-RestMethod -Uri $tokenUrl -Method Post -Body $body -ContentType 'application/json' -TimeoutSec 30
         $script:BearerToken = $response.bearer_token
         $script:TokenExpiresAt = [DateTime]::Parse($response.expires_at)
+        Write-Host "Authentication successful." -ForegroundColor Green
         Write-Verbose "Obtained bearer token, expires at $script:TokenExpiresAt"
         return $script:BearerToken
     }
     catch {
+        Write-Host "Authentication failed." -ForegroundColor Red
         throw "Failed to obtain bearer token: $_"
     }
 }
@@ -85,7 +91,7 @@ function Invoke-OpaApiRequest {
     }
 
     try {
-        $response = Invoke-RestMethod @params
+        $response = Invoke-RestMethod @params -TimeoutSec 30
         return $response
     }
     catch {


### PR DESCRIPTION
## Summary
- Add "Authenticating to OPA API..." status message after credential entry
- Add 30-second timeout to Invoke-RestMethod calls (prevents indefinite hangs)
- Ensure TLS 1.2 is enabled for older Windows versions
- Add success/failure feedback messages

## Test plan
- [ ] Re-run module and verify progress messages appear
- [ ] If still hanging, timeout will occur after 30 seconds with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)