### PR TITLE
Fix credential input and skip cmdkey storage

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Get-OpaCredential.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Get-OpaCredential.ps1
@@ -34,32 +34,18 @@ function Get-OpaCredential {
             throw "Key-ID is required"
         }
 
-        $keySecretSecure = Read-Host "Enter Key-Secret" -AsSecureString
+        # Use plain text input to avoid SecureString issues with pasting
+        $keySecret = Read-Host "Enter Key-Secret"
         Write-Host "Processing credentials..." -ForegroundColor Yellow
 
-        $keySecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
-            [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($keySecretSecure)
-        )
         if ([string]::IsNullOrWhiteSpace($keySecret)) {
             throw "Key-Secret is required"
         }
         Write-Verbose "Key-Secret received (length: $($keySecret.Length))"
 
-        Write-Host "Storing credentials..." -ForegroundColor Yellow
-        try {
-            Write-Verbose "Deleting any existing credential..."
-            $deleteResult = cmdkey /delete:$script:CredentialTarget 2>&1
-            Write-Verbose "Delete result: $deleteResult"
-
-            Write-Verbose "Storing new credential..."
-            $addResult = cmdkey /generic:$script:CredentialTarget /user:$keyId /pass:$keySecret 2>&1
-            Write-Verbose "Add result: $addResult"
-
-            Write-Host "Credentials stored in Windows Credential Manager." -ForegroundColor Green
-        }
-        catch {
-            Write-Warning "Failed to store credentials: $_"
-        }
+        # Skip credential storage for now - just use in-memory for this session
+        Write-Host "Credentials loaded for this session." -ForegroundColor Green
+        Write-Verbose "Skipping Windows Credential Manager storage to avoid cmdkey issues"
     }
 
     return @{


### PR DESCRIPTION
## Summary
- Use plain Read-Host instead of -AsSecureString (SecureString was only capturing 1 char when pasting)
- Skip cmdkey storage which was hanging indefinitely
- Credentials work for current session only (will prompt each time)

## Test plan
- [ ] Re-run module, paste full Key-Secret
- [ ] Verify API authentication proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)