### PR TITLE
Make event lookback days configurable

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Initialize-OpaConfig.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Initialize-OpaConfig.ps1
@@ -6,6 +6,7 @@ function Initialize-OpaConfig {
         opa_url = ''
         team_name = ''
         timestamp_tolerance_seconds = 120
+        event_lookback_days = 7
         secrets_resource_group = ''
         secrets_project = ''
         secrets_id = ''
@@ -18,6 +19,9 @@ function Initialize-OpaConfig {
             if ($fileConfig.team_name) { $config.team_name = $fileConfig.team_name }
             if ($fileConfig.timestamp_tolerance_seconds) {
                 $config.timestamp_tolerance_seconds = $fileConfig.timestamp_tolerance_seconds
+            }
+            if ($fileConfig.event_lookback_days) {
+                $config.event_lookback_days = $fileConfig.event_lookback_days
             }
             if ($fileConfig.secrets_resource_group) { $config.secrets_resource_group = $fileConfig.secrets_resource_group }
             if ($fileConfig.secrets_project) { $config.secrets_project = $fileConfig.secrets_project }
@@ -69,6 +73,7 @@ function Initialize-OpaConfig {
         opa_url = $config.opa_url
         team_name = $config.team_name
         timestamp_tolerance_seconds = $config.timestamp_tolerance_seconds
+        event_lookback_days = $config.event_lookback_days
         secrets_resource_group = $config.secrets_resource_group
         secrets_project = $config.secrets_project
         secrets_id = $config.secrets_id

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -5,15 +5,19 @@ function Compare-OpaAdRotations {
 
         [string]$Domain,
 
-        [int]$EventDays = 7
+        [int]$LookbackDays = 0
     )
 
     $config = Initialize-OpaConfig
     $toleranceSeconds = $config.timestamp_tolerance_seconds
 
+    # Use CLI parameter if provided, otherwise use config value
+    $eventDays = if ($LookbackDays -gt 0) { $LookbackDays } else { $config.event_lookback_days }
+
     Write-Host "OPA AD Rotation Verification" -ForegroundColor Cyan
     Write-Host "=============================" -ForegroundColor Cyan
     Write-Host "Tolerance: $toleranceSeconds seconds"
+    Write-Host "Event Lookback: $eventDays days"
     Write-Host ""
 
     $connection = Get-OpaAdConnection -Domain $Domain
@@ -34,7 +38,7 @@ function Compare-OpaAdRotations {
     foreach ($account in $accounts) {
         Write-Verbose "Processing account: $($account.Username)"
 
-        $adHistory = Get-AdPasswordHistory -UserPrincipalName $account.Username -Days $EventDays
+        $adHistory = Get-AdPasswordHistory -UserPrincipalName $account.Username -Days $eventDays
 
         $opaTimestamp = $null
         if ($account.LastPasswordChangeSuccessTimestamp) {

--- a/diagnostics/AD_Pwd_Tracking/config.json
+++ b/diagnostics/AD_Pwd_Tracking/config.json
@@ -2,6 +2,7 @@
   "opa_url": "",
   "team_name": "",
   "timestamp_tolerance_seconds": 120,
+  "event_lookback_days": 7,
   "secrets_resource_group": "",
   "secrets_project": "",
   "secrets_id": ""


### PR DESCRIPTION
## Summary
- Add `event_lookback_days` to config.json (default: 7)
- Add `-LookbackDays` CLI parameter to override config
- Display lookback period in output

## Usage
```powershell
# Use config value (default 7 days)
Compare-OpaAdRotations

# Override with CLI parameter
Compare-OpaAdRotations -LookbackDays 14
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)