### PR TITLE
Query event logs across all domain controllers

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-AdPasswordHistory.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-AdPasswordHistory.ps1
@@ -33,10 +33,20 @@ function Get-AdPasswordHistory {
     $passwordEvents = @()
     $startTime = (Get-Date).AddDays(-$Days)
 
+    # Get all domain controllers
+    $domainControllers = @()
     try {
-        # Event ID 4723: User changed their own password
-        # Event ID 4724: Password was reset by admin/service account
-        $filterXml = @"
+        $domainControllers = Get-ADDomainController -Filter * | Select-Object -ExpandProperty HostName
+        Write-Verbose "Found $($domainControllers.Count) domain controllers: $($domainControllers -join ', ')"
+    }
+    catch {
+        Write-Warning "Failed to enumerate domain controllers, using local machine: $_"
+        $domainControllers = @($env:COMPUTERNAME)
+    }
+
+    # Event ID 4723: User changed their own password
+    # Event ID 4724: Password was reset by admin/service account
+    $filterXml = @"
 <QueryList>
   <Query Id="0" Path="Security">
     <Select Path="Security">
@@ -47,44 +57,59 @@ function Get-AdPasswordHistory {
   </Query>
 </QueryList>
 "@
-        $events = Get-WinEvent -FilterXml $filterXml -ErrorAction SilentlyContinue
 
-        foreach ($event in $events) {
-            $eventXml = [xml]$event.ToXml()
-            $eventData = @{}
-            $eventXml.Event.EventData.Data | ForEach-Object {
-                $eventData[$_.Name] = $_.'#text'
+    foreach ($dc in $domainControllers) {
+        Write-Verbose "Querying event log on $dc..."
+        try {
+            $events = Get-WinEvent -ComputerName $dc -FilterXml $filterXml -ErrorAction SilentlyContinue
+
+            foreach ($event in $events) {
+                $eventXml = [xml]$event.ToXml()
+                $eventData = @{}
+                $eventXml.Event.EventData.Data | ForEach-Object {
+                    $eventData[$_.Name] = $_.'#text'
+                }
+
+                $eventType = switch ($event.Id) {
+                    4723 { 'SelfChange' }
+                    4724 { 'Reset' }
+                    default { 'Unknown' }
+                }
+
+                $passwordEvents += [PSCustomObject]@{
+                    TimeCreated = $event.TimeCreated
+                    EventId = $event.Id
+                    EventType = $eventType
+                    DomainController = $dc
+                    SubjectUserName = $eventData['SubjectUserName']
+                    SubjectDomainName = $eventData['SubjectDomainName']
+                    TargetUserName = $eventData['TargetUserName']
+                    TargetDomainName = $eventData['TargetDomainName']
+                }
             }
 
-            $eventType = switch ($event.Id) {
-                4723 { 'SelfChange' }
-                4724 { 'Reset' }
-                default { 'Unknown' }
-            }
-
-            $passwordEvents += [PSCustomObject]@{
-                TimeCreated = $event.TimeCreated
-                EventId = $event.Id
-                EventType = $eventType
-                SubjectUserName = $eventData['SubjectUserName']
-                SubjectDomainName = $eventData['SubjectDomainName']
-                TargetUserName = $eventData['TargetUserName']
-                TargetDomainName = $eventData['TargetDomainName']
+            $dcEventCount = ($events | Measure-Object).Count
+            if ($dcEventCount -gt 0) {
+                Write-Verbose "  Found $dcEventCount events on $dc"
             }
         }
+        catch {
+            Write-Warning "Failed to query event log on $dc : $_"
+        }
+    }
 
-        Write-Verbose "Found $($passwordEvents.Count) password change events (4723/4724) for $samAccountName in last $Days days"
-    }
-    catch {
-        Write-Warning "Failed to query Security Event Log: $_"
-    }
+    # Remove duplicate events (same event may be logged on multiple DCs via replication)
+    $uniqueEvents = $passwordEvents | Sort-Object TimeCreated, EventId, SubjectUserName -Unique
+
+    Write-Verbose "Found $($uniqueEvents.Count) unique password change events (4723/4724) for $samAccountName in last $Days days"
 
     return [PSCustomObject]@{
         UserPrincipalName = $UserPrincipalName
         SamAccountName = $samAccountName
         AdUserFound = ($null -ne $adUser)
         PasswordLastSet = $passwordLastSet
-        PasswordEvents = $passwordEvents
-        EventCount = $passwordEvents.Count
+        PasswordEvents = $uniqueEvents
+        EventCount = $uniqueEvents.Count
+        DomainControllersQueried = $domainControllers
     }
 }


### PR DESCRIPTION
## Summary
- Enumerate all DCs with Get-ADDomainController
- Query Security event log on each DC via -ComputerName
- Deduplicate events that appear on multiple DCs
- Track which DC logged each event

🤖 Generated with [Claude Code](https://claude.com/claude-code)