### PR TITLE
Require PowerShell 7 and update README

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psd1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Okta'
     Copyright = '(c) 2024 Okta. All rights reserved.'
     Description = 'Verifies OPA Active Directory credential rotations against actual AD password changes'
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.0'
     RequiredModules = @('ActiveDirectory')
     FunctionsToExport = @(
         'Compare-OpaAdRotations',

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psm1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psm1
@@ -1,3 +1,8 @@
+# Require PowerShell 7.x
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    throw "This module requires PowerShell 7.x or later. Current version: $($PSVersionTable.PSVersion). Please run with 'pwsh' instead of 'powershell'."
+}
+
 $script:ModuleRoot = $PSScriptRoot
 $script:ConfigPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'config.json'
 $script:CredentialTarget = 'OPA-ADRotationVerifier'

--- a/diagnostics/AD_Pwd_Tracking/README.md
+++ b/diagnostics/AD_Pwd_Tracking/README.md
@@ -6,25 +6,34 @@
 
 PowerShell module for verifying Okta Privileged Access (OPA) Active Directory credential rotations against actual AD password change records. Compares OPA's rotation timestamps with AD's PasswordLastSet attribute and Security Event Log entries to ensure rotations are occurring correctly and detect unauthorized password changes.
 
-## Disclaimer
+## Requirements
 
-This module is provided as-is for diagnostic and verification purposes. It requires:
+- **PowerShell 7.x** (pwsh) - Windows PowerShell 5.1 is not supported
 - Domain Controller or domain-joined server with AD PowerShell module
 - OPA Service Account API credentials (Key-ID and Key-Secret)
-- Read access to Security Event Log (Event ID 4724)
+- Read access to Security Event Log (Event IDs 4723, 4724)
 - Network access to OPA API endpoints
 
-Always test in a non-production environment first. The module stores API credentials in Windows Credential Manager - ensure appropriate access controls on the server.
+### OPA Service User Permissions
+
+The OPA Service User used for API authentication requires the following roles:
+- **Resource Admin** - to access AD connection and account information
+- **Security Admin** - to access rotation status and password change details
+
+## Disclaimer
+
+This module is provided as-is for diagnostic and verification purposes. Always test in a non-production environment first.
 
 ## Capabilities
 
 - Auto-detects local AD domain and matches to OPA AD connection
 - Retrieves all OPA-managed AD accounts and their rotation status
 - Queries AD for actual PasswordLastSet timestamps (via UPN lookup)
-- Analyzes Security Event Log for password change events (last 7 days)
+- Analyzes Security Event Log for password change events across all domain controllers
 - Identifies discrepancies between OPA rotation records and AD state
 - Detects password changes made by processes other than OPA
 - Configurable timestamp tolerance (default: 2 minutes)
+- Configurable event lookback period (default: 7 days)
 - Exports detailed CSV reports for audit/compliance
 
 ## Installation
@@ -32,11 +41,11 @@ Always test in a non-production environment first. The module stores API credent
 ### Download via curl
 
 ```powershell
-# Set base URL and module path
+# Set base URL and module path (system-wide for PowerShell 7)
 $baseUrl = "https://raw.githubusercontent.com/Okta-PAM-Resource-Kit/scripts/main/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier"
-$modulePath = "$env:USERPROFILE\Documents\PowerShell\Modules\OPA-ADRotationVerifier"
+$modulePath = "$env:ProgramFiles\PowerShell\Modules\OPA-ADRotationVerifier"
 
-# Create module directory structure
+# Create module directory structure (requires admin)
 New-Item -ItemType Directory -Path "$modulePath\Private" -Force
 New-Item -ItemType Directory -Path "$modulePath\Public" -Force
 
@@ -78,6 +87,9 @@ Compare-OpaAdRotations -Verbose
 
 # Export results to CSV
 Compare-OpaAdRotations -ExportPath "C:\Reports\rotation-report.csv"
+
+# Force token refresh
+Compare-OpaAdRotations -ForceTokenRefresh
 ```
 
 ## Configuration
@@ -85,10 +97,11 @@ Compare-OpaAdRotations -ExportPath "C:\Reports\rotation-report.csv"
 On first run, the module prompts for:
 1. **OPA URL** - e.g., `https://myorg.pam.okta.com`
 2. **Team Name** - your OPA team identifier
-3. **Key-ID** - OPA Service Account key ID
-4. **Key-Secret** - OPA Service Account key secret
+3. **Secrets Resource Group** - OPA resource group containing API credentials
+4. **Secrets Project** - OPA project containing API credentials
+5. **Secret ID** - UUID of the secret containing apikey/apisecret
 
-Settings are stored in `config.json` (URL/team/secrets config).
+Settings are stored in `config.json`.
 
 ## Additional Scripts
 


### PR DESCRIPTION
## Summary
- Add PS7 version check - throws clear error if running under Windows PowerShell
- Update manifest to require PowerShellVersion 7.0
- Change module path to system-wide location
- Document PS7 requirement and OPA Service User role requirements (Resource Admin, Security Admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)