### PR TITLE
Clarify PowerShell 7 or later requirement

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psm1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psm1
@@ -1,6 +1,6 @@
-# Require PowerShell 7.x
+# Require PowerShell 7 or later
 if ($PSVersionTable.PSVersion.Major -lt 7) {
-    throw "This module requires PowerShell 7.x or later. Current version: $($PSVersionTable.PSVersion). Please run with 'pwsh' instead of 'powershell'."
+    throw "This module requires PowerShell 7 or later. Current version: $($PSVersionTable.PSVersion). Please run with 'pwsh' instead of 'powershell'."
 }
 
 $script:ModuleRoot = $PSScriptRoot

--- a/diagnostics/AD_Pwd_Tracking/README.md
+++ b/diagnostics/AD_Pwd_Tracking/README.md
@@ -8,7 +8,7 @@ PowerShell module for verifying Okta Privileged Access (OPA) Active Directory cr
 
 ## Requirements
 
-- **PowerShell 7.x** (pwsh) - Windows PowerShell 5.1 is not supported
+- **PowerShell 7 or later** (pwsh) - Windows PowerShell 5.1 is not supported
 - Domain Controller or domain-joined server with AD PowerShell module
 - OPA Service Account API credentials (Key-ID and Key-Secret)
 - Read access to Security Event Log (Event IDs 4723, 4724)


### PR DESCRIPTION
Consistent wording: '7 or later' instead of '7.x'