### PR TITLE
Add ShowDetails and ForceRotation options

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -7,7 +7,11 @@ function Compare-OpaAdRotations {
 
         [int]$LookbackDays = 0,
 
-        [switch]$ForceTokenRefresh
+        [switch]$ForceTokenRefresh,
+
+        [switch]$ShowDetails,
+
+        [switch]$ForceRotation
     )
 
     # Clear cached token if force refresh requested
@@ -90,6 +94,7 @@ function Compare-OpaAdRotations {
         }
 
         $results += [PSCustomObject]@{
+            AccountId = $account.Id
             Account = $account.Username
             Status = $status
             OpaLastRotation = $opaTimestamp
@@ -103,61 +108,84 @@ function Compare-OpaAdRotations {
         }
     }
 
-    Write-Host ""
-    Write-Host "Rotation Comparison Results" -ForegroundColor Cyan
-    Write-Host "============================" -ForegroundColor Cyan
-
     # Group results by status
     $matches = $results | Where-Object { $_.Status -eq 'MATCH' }
     $mismatches = $results | Where-Object { $_.Status -eq 'MISMATCH' }
     $others = $results | Where-Object { $_.Status -notin @('MATCH', 'MISMATCH') }
 
-    # Display matches
-    if ($matches.Count -gt 0) {
-        Write-Host ""
-        Write-Host "=== MATCHES ($($matches.Count)) ===" -ForegroundColor Green
-        foreach ($result in $matches) {
-            Write-Host "  $($result.Account)" -ForegroundColor Green
-            if ($result.DeltaSeconds) {
-                Write-Host "    Delta: $($result.DeltaSeconds) seconds" -ForegroundColor DarkGray
-            }
-        }
-    }
-
-    # Display mismatches (highlighted)
-    if ($mismatches.Count -gt 0) {
-        Write-Host ""
-        Write-Host "=== MISMATCHES ($($mismatches.Count)) ===" -ForegroundColor Red -BackgroundColor Black
-        foreach ($result in $mismatches) {
-            Write-Host "  $($result.Account)" -ForegroundColor Red -BackgroundColor Black
-            Write-Host "    OPA Last Rotation:  $($result.OpaLastRotation)" -ForegroundColor Red
-            Write-Host "    AD PasswordLastSet: $($result.AdPasswordLastSet)" -ForegroundColor Red
-            Write-Host "    Delta: $($result.DeltaSeconds) seconds" -ForegroundColor Red
-            if ($result.OtherChangers) {
-                Write-Host "    Non-OPA changes: $($result.OtherChangers)" -ForegroundColor Yellow
-            }
-        }
-    }
-
-    # Display others
-    if ($others.Count -gt 0) {
-        Write-Host ""
-        Write-Host "=== OTHER ($($others.Count)) ===" -ForegroundColor Yellow
-        foreach ($result in $others) {
-            Write-Host "  $($result.Account) - $($result.Status)" -ForegroundColor Yellow
-            if ($result.OtherChangers) {
-                Write-Host "    Non-OPA changes: $($result.OtherChangers)" -ForegroundColor Yellow
-            }
-        }
-    }
-
     Write-Host ""
-    Write-Host "Summary: " -NoNewline
+    Write-Host "Summary" -ForegroundColor Cyan
+    Write-Host "=======" -ForegroundColor Cyan
     Write-Host "$($matches.Count) MATCH" -ForegroundColor Green -NoNewline
     Write-Host ", " -NoNewline
     Write-Host "$($mismatches.Count) MISMATCH" -ForegroundColor Red -NoNewline
     Write-Host ", " -NoNewline
     Write-Host "$($others.Count) OTHER" -ForegroundColor Yellow
+
+    # Show detailed rotation info only if -ShowDetails or -ExportPath specified
+    if ($ShowDetails -or $ExportPath) {
+        Write-Host ""
+        Write-Host "Rotation Details" -ForegroundColor Cyan
+        Write-Host "================" -ForegroundColor Cyan
+
+        # Display matches
+        if ($matches.Count -gt 0) {
+            Write-Host ""
+            Write-Host "=== MATCHES ($($matches.Count)) ===" -ForegroundColor Green
+            foreach ($result in $matches) {
+                Write-Host "  $($result.Account)" -ForegroundColor Green
+                if ($result.DeltaSeconds) {
+                    Write-Host "    Delta: $($result.DeltaSeconds) seconds" -ForegroundColor DarkGray
+                }
+            }
+        }
+
+        # Display mismatches (highlighted)
+        if ($mismatches.Count -gt 0) {
+            Write-Host ""
+            Write-Host "=== MISMATCHES ($($mismatches.Count)) ===" -ForegroundColor Red -BackgroundColor Black
+            foreach ($result in $mismatches) {
+                Write-Host "  $($result.Account)" -ForegroundColor Red -BackgroundColor Black
+                Write-Host "    OPA Last Rotation:  $($result.OpaLastRotation)" -ForegroundColor Red
+                Write-Host "    AD PasswordLastSet: $($result.AdPasswordLastSet)" -ForegroundColor Red
+                Write-Host "    Delta: $($result.DeltaSeconds) seconds" -ForegroundColor Red
+                if ($result.OtherChangers) {
+                    Write-Host "    Non-OPA changes: $($result.OtherChangers)" -ForegroundColor Yellow
+                }
+            }
+        }
+
+        # Display others
+        if ($others.Count -gt 0) {
+            Write-Host ""
+            Write-Host "=== OTHER ($($others.Count)) ===" -ForegroundColor Yellow
+            foreach ($result in $others) {
+                Write-Host "  $($result.Account) - $($result.Status)" -ForegroundColor Yellow
+                if ($result.OtherChangers) {
+                    Write-Host "    Non-OPA changes: $($result.OtherChangers)" -ForegroundColor Yellow
+                }
+            }
+        }
+    }
+
+    # Force rotation for mismatched accounts
+    if ($ForceRotation -and $mismatches.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Forcing Password Rotation for Mismatched Accounts" -ForegroundColor Cyan
+        Write-Host "==================================================" -ForegroundColor Cyan
+
+        foreach ($mismatch in $mismatches) {
+            Write-Host "  Rotating: $($mismatch.Account)..." -ForegroundColor Yellow -NoNewline
+            try {
+                $rotateEndpoint = "/v1/teams/$($config.team_name)/active_directory/$($connection.id)/accounts/$($mismatch.AccountId)/rotate_password"
+                $null = Invoke-OpaApiRequest -Endpoint $rotateEndpoint -Method 'POST' -Config $config
+                Write-Host " OK" -ForegroundColor Green
+            }
+            catch {
+                Write-Host " FAILED: $_" -ForegroundColor Red
+            }
+        }
+    }
 
     if ($ExportPath) {
         Export-RotationReport -Results $results -Path $ExportPath


### PR DESCRIPTION
## Summary
- Renamed detailed section to "Rotation Details"
- Details only shown with `-ShowDetails` or `-ExportPath`
- Added `-ForceRotation` to trigger rotation for MISMATCHED accounts via OPA API
- Summary (counts) now shown first

## Usage
```powershell
# Summary only (default)
Compare-OpaAdRotations

# Show full details
Compare-OpaAdRotations -ShowDetails

# Force rotation for mismatched accounts
Compare-OpaAdRotations -ForceRotation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)