### PR TITLE
Add pagination support for AD accounts API

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Invoke-OpaApiRequest.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Invoke-OpaApiRequest.ps1
@@ -58,13 +58,15 @@ function Invoke-OpaApiRequest {
         [object]$Body,
 
         [Parameter(Mandatory)]
-        [hashtable]$Config
+        [hashtable]$Config,
+
+        [switch]$IncludeHeaders
     )
 
     # Get token - will use cached token or prompt for credentials if needed
     $token = Get-OpaToken -Config $Config
 
-    $url = "$($Config.opa_url)$Endpoint"
+    $url = if ($Endpoint -match '^https?://') { $Endpoint } else { "$($Config.opa_url)$Endpoint" }
     $headers = @{
         'Authorization' = "Bearer $token"
         'Accept' = 'application/json'
@@ -84,8 +86,18 @@ function Invoke-OpaApiRequest {
     }
 
     try {
-        $response = Invoke-RestMethod @params -TimeoutSec 30
-        return $response
+        if ($IncludeHeaders) {
+            $response = Invoke-WebRequest @params -TimeoutSec 30
+            $content = $response.Content | ConvertFrom-Json
+            return @{
+                Content = $content
+                Headers = $response.Headers
+            }
+        }
+        else {
+            $response = Invoke-RestMethod @params -TimeoutSec 30
+            return $response
+        }
     }
     catch {
         $statusCode = $_.Exception.Response.StatusCode.value__

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
@@ -2,7 +2,9 @@ function Get-OpaAdAccounts {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$ConnectionId
+        [string]$ConnectionId,
+
+        [switch]$ValidateTimestamps
     )
 
     $config = Initialize-OpaConfig
@@ -10,27 +12,58 @@ function Get-OpaAdAccounts {
     $endpoint = "/v1/teams/$($config.team_name)/resource_assignment/active_directory/$ConnectionId/accounts"
     Write-Verbose "Fetching AD accounts from $endpoint"
 
-    $response = Invoke-OpaApiRequest -Endpoint $endpoint -Config $config
+    $allAccounts = @()
+    $currentEndpoint = $endpoint
+    $pageNum = 1
 
-    Write-Verbose "Response type: $($response.GetType().FullName)"
-    Write-Verbose "Response content: $($response | ConvertTo-Json -Depth 3 -Compress)"
+    do {
+        Write-Verbose "Fetching page $pageNum from $currentEndpoint"
+        $response = Invoke-OpaApiRequest -Endpoint $currentEndpoint -Config $config -IncludeHeaders
 
-    $accounts = @()
-    if ($response.list -and $response.list.Count -gt 0) {
-        $accounts = $response.list
-    }
-    elseif ($response.accounts -and $response.accounts.Count -gt 0) {
-        $accounts = $response.accounts
-    }
-    elseif ($response -is [array]) {
-        $accounts = $response
-    }
+        $content = $response.Content
+        Write-Verbose "Response type: $($content.GetType().FullName)"
+        Write-Verbose "Response content: $($content | ConvertTo-Json -Depth 3 -Compress)"
+
+        $pageAccounts = @()
+        if ($content.list -and $content.list.Count -gt 0) {
+            $pageAccounts = $content.list
+        }
+        elseif ($content.accounts -and $content.accounts.Count -gt 0) {
+            $pageAccounts = $content.accounts
+        }
+        elseif ($content -is [array]) {
+            $pageAccounts = $content
+        }
+
+        $allAccounts += $pageAccounts
+        Write-Verbose "Page $pageNum returned $($pageAccounts.Count) accounts (total: $($allAccounts.Count))"
+
+        $nextUrl = $null
+        $linkHeader = $response.Headers['Link']
+        if ($linkHeader) {
+            $linkValue = if ($linkHeader -is [array]) { $linkHeader[0] } else { $linkHeader }
+            Write-Verbose "Link header: $linkValue"
+            if ($linkValue -match '<([^>]+)>;\s*rel="next"') {
+                $nextUrl = $Matches[1]
+                Write-Verbose "Found next page URL: $nextUrl"
+            }
+        }
+
+        $currentEndpoint = $nextUrl
+        $pageNum++
+    } while ($currentEndpoint)
+
+    $accounts = $allAccounts
 
     Write-Verbose "Retrieved $($accounts.Count) managed accounts"
 
     $accountsWithRotation = @()
+    $timestampMatches = 0
+    $timestampMismatches = 0
+
     foreach ($account in $accounts) {
         $accountUpn = if ($account.upn) { $account.upn } else { $account.username }
+        $listLastRotation = $account.last_rotation_at
         Write-Verbose "Fetching rotation details for account: $accountUpn"
 
         $detailEndpoint = "/v1/teams/$($config.team_name)/resource_assignment/active_directory/$ConnectionId/accounts/$($account.id)"
@@ -38,6 +71,20 @@ function Get-OpaAdAccounts {
             $detail = Invoke-OpaApiRequest -Endpoint $detailEndpoint -Config $config
 
             Write-Verbose "Detail response: $($detail | ConvertTo-Json -Depth 3 -Compress)"
+
+            if ($ValidateTimestamps) {
+                $detailTimestamp = $detail.last_password_change_success_report_timestamp
+                if ($listLastRotation -eq $detailTimestamp) {
+                    $timestampMatches++
+                    Write-Verbose "MATCH: $accountUpn - List: $listLastRotation, Detail: $detailTimestamp"
+                }
+                else {
+                    $timestampMismatches++
+                    Write-Host "MISMATCH: $accountUpn" -ForegroundColor Yellow
+                    Write-Host "  List API last_rotation_at:                      $listLastRotation" -ForegroundColor Yellow
+                    Write-Host "  Detail API last_password_change_success_report: $detailTimestamp" -ForegroundColor Yellow
+                }
+            }
 
             $accountsWithRotation += [PSCustomObject]@{
                 Id = $detail.id
@@ -84,6 +131,18 @@ function Get-OpaAdAccounts {
                 NextScheduledRotation = $null
                 NextScheduledRotationReason = $null
             }
+        }
+    }
+
+    if ($ValidateTimestamps) {
+        Write-Host ""
+        Write-Host "Timestamp Validation Summary" -ForegroundColor Cyan
+        Write-Host "============================" -ForegroundColor Cyan
+        Write-Host "Matches:    $timestampMatches" -ForegroundColor Green
+        Write-Host "Mismatches: $timestampMismatches" -ForegroundColor $(if ($timestampMismatches -gt 0) { 'Red' } else { 'Green' })
+        if ($timestampMismatches -eq 0) {
+            Write-Host ""
+            Write-Host "All timestamps match - individual account calls could be eliminated." -ForegroundColor Green
         }
     }
 


### PR DESCRIPTION
## Summary
- Support paginated responses from list accounts endpoint by following `rel="next"` Link headers
- Add `-ValidateTimestamps` switch to compare list API `last_rotation_at` with detail API `last_password_change_success_report` timestamps
- If timestamps always match, individual account API calls could be eliminated to reduce API overhead

## Test plan
- [ ] Run `Get-OpaAdAccounts -ConnectionId <id> -ValidateTimestamps -Verbose` to validate timestamp consistency
- [ ] Verify pagination works with large account sets (>100 accounts)

🤖 Generated with [Claude Code](https://claude.ai/code)