### PR TITLE
Add ValidateTimestamps passthrough to Compare-OpaAdRotations

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -11,7 +11,9 @@ function Compare-OpaAdRotations {
 
         [switch]$ShowDetails,
 
-        [switch]$ForceRotation
+        [switch]$ForceRotation,
+
+        [switch]$ValidateTimestamps
     )
 
     # Clear cached token if force refresh requested
@@ -42,7 +44,9 @@ function Compare-OpaAdRotations {
     Write-Host ""
 
     Write-Host "Fetching managed accounts..." -ForegroundColor Yellow
-    $accounts = Get-OpaAdAccounts -ConnectionId $connection.id
+    $accountParams = @{ ConnectionId = $connection.id }
+    if ($ValidateTimestamps) { $accountParams.ValidateTimestamps = $true }
+    $accounts = Get-OpaAdAccounts @accountParams
     Write-Host "Found $($accounts.Count) managed accounts" -ForegroundColor Green
     Write-Host ""
 


### PR DESCRIPTION
## Summary
- Add `-ValidateTimestamps` parameter to `Compare-OpaAdRotations`
- Passes through to `Get-OpaAdAccounts` so connection ID is auto-detected

## Test plan
- [ ] Run `Compare-OpaAdRotations -ValidateTimestamps`

🤖 Generated with [Claude Code](https://claude.ai/code)