### PR TITLE
Optimize API calls for AD rotation verification

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psd1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psd1
@@ -12,6 +12,7 @@
         'Compare-OpaAdRotations',
         'Get-OpaAdConnection',
         'Get-OpaAdAccounts',
+        'Get-OpaAdAccountDetail',
         'Get-AdPasswordHistory',
         'Export-RotationReport'
     )

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psm1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/OPA-ADRotationVerifier.psm1
@@ -24,6 +24,7 @@ Export-ModuleMember -Function @(
     'Compare-OpaAdRotations',
     'Get-OpaAdConnection',
     'Get-OpaAdAccounts',
+    'Get-OpaAdAccountDetail',
     'Get-AdPasswordHistory',
     'Export-RotationReport'
 )

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -11,9 +11,7 @@ function Compare-OpaAdRotations {
 
         [switch]$ShowDetails,
 
-        [switch]$ForceRotation,
-
-        [switch]$ValidateTimestamps
+        [switch]$ForceRotation
     )
 
     # Clear cached token if force refresh requested
@@ -44,23 +42,23 @@ function Compare-OpaAdRotations {
     Write-Host ""
 
     Write-Host "Fetching managed accounts..." -ForegroundColor Yellow
-    $accountParams = @{ ConnectionId = $connection.id }
-    if ($ValidateTimestamps) { $accountParams.ValidateTimestamps = $true }
-    $accounts = Get-OpaAdAccounts @accountParams
+    $accounts = Get-OpaAdAccounts -ConnectionId $connection.id
     Write-Host "Found $($accounts.Count) managed accounts" -ForegroundColor Green
     Write-Host ""
 
     $results = @()
+    $detailFetchCount = 0
 
     foreach ($account in $accounts) {
         Write-Verbose "Processing account: $($account.Username)"
 
         $adHistory = Get-AdPasswordHistory -UserPrincipalName $account.Username -Days $eventDays
 
+        # First try comparing with last_rotation_at from list API
         $opaTimestamp = $null
-        if ($account.LastPasswordChangeSuccessTimestamp) {
+        if ($account.LastRotationAt) {
             try {
-                $opaTimestamp = [DateTime]::Parse($account.LastPasswordChangeSuccessTimestamp)
+                $opaTimestamp = [DateTime]::Parse($account.LastRotationAt)
             }
             catch {
                 Write-Warning "Failed to parse OPA timestamp for $($account.Username)"
@@ -70,6 +68,9 @@ function Compare-OpaAdRotations {
         $adTimestamp = $adHistory.PasswordLastSet
         $deltaSeconds = $null
         $status = 'UNKNOWN'
+        $rotationFailed = $false
+        $opaSuccessCount = $null
+        $opaErrorCount = $null
 
         if (-not $adHistory.AdUserFound) {
             $status = 'AD_USER_NOT_FOUND'
@@ -86,7 +87,39 @@ function Compare-OpaAdRotations {
                 $status = 'MATCH'
             }
             else {
-                $status = 'MISMATCH'
+                # Mismatch with list API - fetch detail to check last successful rotation
+                Write-Verbose "Mismatch detected for $($account.Username), fetching detail API..."
+                $detailFetchCount++
+
+                try {
+                    $detail = Get-OpaAdAccountDetail -ConnectionId $connection.id -AccountId $account.Id
+                    $opaSuccessCount = $detail.PasswordChangeSuccessCount
+                    $opaErrorCount = $detail.PasswordChangeErrorCount
+
+                    if ($detail.LastPasswordChangeSuccessTimestamp) {
+                        $successTimestamp = [DateTime]::Parse($detail.LastPasswordChangeSuccessTimestamp)
+                        $successDelta = [Math]::Abs(($successTimestamp - $adTimestamp).TotalSeconds)
+
+                        if ($successDelta -le $toleranceSeconds) {
+                            # AD matches last successful rotation - recent attempt failed
+                            $status = 'MATCH'
+                            $rotationFailed = $true
+                            $opaTimestamp = $successTimestamp
+                            $deltaSeconds = $successDelta
+                            Write-Verbose "AD matches last successful rotation (recent attempt failed)"
+                        }
+                        else {
+                            $status = 'MISMATCH'
+                        }
+                    }
+                    else {
+                        $status = 'MISMATCH'
+                    }
+                }
+                catch {
+                    Write-Warning "Failed to fetch detail for $($account.Username): $_"
+                    $status = 'MISMATCH'
+                }
             }
         }
 
@@ -101,11 +134,12 @@ function Compare-OpaAdRotations {
             AccountId = $account.Id
             Account = $account.Username
             Status = $status
+            RotationFailed = $rotationFailed
             OpaLastRotation = $opaTimestamp
             AdPasswordLastSet = $adTimestamp
             DeltaSeconds = $deltaSeconds
-            OpaSuccessCount = $account.PasswordChangeSuccessCount
-            OpaErrorCount = $account.PasswordChangeErrorCount
+            OpaSuccessCount = $opaSuccessCount
+            OpaErrorCount = $opaErrorCount
             RecentAdEvents = $adHistory.EventCount
             OtherChangers = ($otherChangers -join '; ')
             AdUserFound = $adHistory.AdUserFound
@@ -125,6 +159,7 @@ function Compare-OpaAdRotations {
     Write-Host "$($mismatches.Count) MISMATCH" -ForegroundColor Red -NoNewline
     Write-Host ", " -NoNewline
     Write-Host "$($others.Count) OTHER" -ForegroundColor Yellow
+    Write-Host "Detail API calls: $detailFetchCount (only fetched for AD mismatches)" -ForegroundColor DarkGray
 
     # Show detailed rotation info only if -ShowDetails or -ExportPath specified
     if ($ShowDetails -or $ExportPath) {
@@ -140,6 +175,9 @@ function Compare-OpaAdRotations {
                 Write-Host "  $($result.Account)" -ForegroundColor Green
                 if ($result.DeltaSeconds) {
                     Write-Host "    Delta: $($result.DeltaSeconds) seconds" -ForegroundColor DarkGray
+                }
+                if ($result.RotationFailed) {
+                    Write-Host "    WARNING: Last rotation attempt failed (AD matches last successful rotation)" -ForegroundColor Yellow
                 }
             }
         }

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
@@ -4,7 +4,7 @@ function Get-OpaAdAccounts {
         [Parameter(Mandatory)]
         [string]$ConnectionId,
 
-        [switch]$ValidateTimestamps
+        [switch]$IncludeRotationDetails
     )
 
     $config = Initialize-OpaConfig
@@ -53,17 +53,23 @@ function Get-OpaAdAccounts {
         $pageNum++
     } while ($currentEndpoint)
 
-    $accounts = $allAccounts
+    Write-Verbose "Retrieved $($allAccounts.Count) managed accounts"
 
-    Write-Verbose "Retrieved $($accounts.Count) managed accounts"
+    if (-not $IncludeRotationDetails) {
+        $results = @()
+        foreach ($account in $allAccounts) {
+            $results += [PSCustomObject]@{
+                Id = $account.id
+                Username = if ($account.upn) { $account.upn } else { $account.username }
+                LastRotationAt = $account.last_rotation_at
+            }
+        }
+        return $results
+    }
 
     $accountsWithRotation = @()
-    $timestampMatches = 0
-    $timestampMismatches = 0
-
-    foreach ($account in $accounts) {
+    foreach ($account in $allAccounts) {
         $accountUpn = if ($account.upn) { $account.upn } else { $account.username }
-        $listLastRotation = $account.last_rotation_at
         Write-Verbose "Fetching rotation details for account: $accountUpn"
 
         $detailEndpoint = "/v1/teams/$($config.team_name)/resource_assignment/active_directory/$ConnectionId/accounts/$($account.id)"
@@ -71,20 +77,6 @@ function Get-OpaAdAccounts {
             $detail = Invoke-OpaApiRequest -Endpoint $detailEndpoint -Config $config
 
             Write-Verbose "Detail response: $($detail | ConvertTo-Json -Depth 3 -Compress)"
-
-            if ($ValidateTimestamps) {
-                $detailTimestamp = $detail.last_password_change_success_report_timestamp
-                if ($listLastRotation -eq $detailTimestamp) {
-                    $timestampMatches++
-                    Write-Verbose "MATCH: $accountUpn - List: $listLastRotation, Detail: $detailTimestamp"
-                }
-                else {
-                    $timestampMismatches++
-                    Write-Host "MISMATCH: $accountUpn" -ForegroundColor Yellow
-                    Write-Host "  List API last_rotation_at:                      $listLastRotation" -ForegroundColor Yellow
-                    Write-Host "  Detail API last_password_change_success_report: $detailTimestamp" -ForegroundColor Yellow
-                }
-            }
 
             $accountsWithRotation += [PSCustomObject]@{
                 Id = $detail.id
@@ -120,7 +112,7 @@ function Get-OpaAdAccounts {
                 DistinguishedName = $null
                 Domain = $null
                 BroughtUnderManagementAt = $null
-                LastRotationAt = $null
+                LastRotationAt = $account.last_rotation_at
                 LastPasswordChangeSuccessTimestamp = $null
                 LastPasswordChangeSystemTimestamp = $null
                 LastPasswordChangeErrorTimestamp = $null
@@ -134,17 +126,44 @@ function Get-OpaAdAccounts {
         }
     }
 
-    if ($ValidateTimestamps) {
-        Write-Host ""
-        Write-Host "Timestamp Validation Summary" -ForegroundColor Cyan
-        Write-Host "============================" -ForegroundColor Cyan
-        Write-Host "Matches:    $timestampMatches" -ForegroundColor Green
-        Write-Host "Mismatches: $timestampMismatches" -ForegroundColor $(if ($timestampMismatches -gt 0) { 'Red' } else { 'Green' })
-        if ($timestampMismatches -eq 0) {
-            Write-Host ""
-            Write-Host "All timestamps match - individual account calls could be eliminated." -ForegroundColor Green
-        }
-    }
-
     return $accountsWithRotation
+}
+
+function Get-OpaAdAccountDetail {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ConnectionId,
+
+        [Parameter(Mandatory)]
+        [string]$AccountId
+    )
+
+    $config = Initialize-OpaConfig
+    $endpoint = "/v1/teams/$($config.team_name)/resource_assignment/active_directory/$ConnectionId/accounts/$AccountId"
+
+    Write-Verbose "Fetching account detail from $endpoint"
+    $detail = Invoke-OpaApiRequest -Endpoint $endpoint -Config $config
+
+    return [PSCustomObject]@{
+        Id = $detail.id
+        Username = $detail.upn
+        AccountType = $detail.account_type
+        CheckoutStatus = $detail.checkout_status
+        DisplayName = $detail.display_name
+        SamAccountName = $detail.sam_account_name
+        DistinguishedName = $detail.distinguished_name
+        Domain = $detail.domain.name
+        BroughtUnderManagementAt = $detail.brought_under_management_at
+        LastRotationAt = $detail.last_rotation_at
+        LastPasswordChangeSuccessTimestamp = $detail.last_password_change_success_report_timestamp
+        LastPasswordChangeSystemTimestamp = $detail.last_password_change_system_timestamp
+        LastPasswordChangeErrorTimestamp = $detail.last_password_change_error_report_timestamp
+        LastPasswordChangeErrorType = $detail.last_password_change_error_type
+        PasswordChangeSuccessCount = $detail.password_change_success_count
+        PasswordChangeErrorCount = $detail.password_change_error_count
+        PasswordChangeErrorCountSinceLastSuccess = $detail.password_change_error_count_since_last_success
+        NextScheduledRotation = $detail.next_scheduled_password_rotation_timestamp
+        NextScheduledRotationReason = $detail.next_scheduled_password_rotation_reason
+    }
 }


### PR DESCRIPTION
## Summary
- Use `last_rotation_at` from list API for initial AD comparison
- Only fetch account detail when mismatch detected (reduces API calls significantly)
- If AD matches `last_password_change_success_report` from detail API, mark as MATCH with "Last rotation attempt failed" warning
- Add `Get-OpaAdAccountDetail` function for on-demand fetches

## Test plan
- [ ] Run `Compare-OpaAdRotations` and verify reduced API calls in output
- [ ] Verify accounts with failed rotations show warning in `-ShowDetails` output

🤖 Generated with [Claude Code](https://claude.ai/code)