### PR TITLE
Add configurable secret key names and -ClearConfig option

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Get-OpaCredential.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Get-OpaCredential.ps1
@@ -25,21 +25,23 @@ function Get-OpaCredential {
 
         $keyId = $null
         $keySecret = $null
+        $keyIdName = $Config.secrets_key_id_name
+        $keySecretName = $Config.secrets_key_secret_name
 
         foreach ($item in $secretData) {
-            if ($item.key_name -eq 'apikey') {
+            if ($item.key_name -eq $keyIdName) {
                 $keyId = $item.secret_value
             }
-            elseif ($item.key_name -eq 'apisecret') {
+            elseif ($item.key_name -eq $keySecretName) {
                 $keySecret = $item.secret_value
             }
         }
 
         if ([string]::IsNullOrWhiteSpace($keyId)) {
-            throw "Could not find 'apikey' in secret response"
+            throw "Could not find '$keyIdName' in secret response"
         }
         if ([string]::IsNullOrWhiteSpace($keySecret)) {
-            throw "Could not find 'apisecret' in secret response"
+            throw "Could not find '$keySecretName' in secret response"
         }
 
         Write-Host "API credentials retrieved successfully." -ForegroundColor Green

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Initialize-OpaConfig.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Private/Initialize-OpaConfig.ps1
@@ -10,6 +10,8 @@ function Initialize-OpaConfig {
         secrets_resource_group = ''
         secrets_project = ''
         secrets_id = ''
+        secrets_key_id_name = ''
+        secrets_key_secret_name = ''
     }
 
     if (Test-Path $script:ConfigPath) {
@@ -26,6 +28,8 @@ function Initialize-OpaConfig {
             if ($fileConfig.secrets_resource_group) { $config.secrets_resource_group = $fileConfig.secrets_resource_group }
             if ($fileConfig.secrets_project) { $config.secrets_project = $fileConfig.secrets_project }
             if ($fileConfig.secrets_id) { $config.secrets_id = $fileConfig.secrets_id }
+            if ($fileConfig.secrets_key_id_name) { $config.secrets_key_id_name = $fileConfig.secrets_key_id_name }
+            if ($fileConfig.secrets_key_secret_name) { $config.secrets_key_secret_name = $fileConfig.secrets_key_secret_name }
         }
         catch {
             Write-Warning "Failed to read config file: $_"
@@ -67,6 +71,20 @@ function Initialize-OpaConfig {
         }
     }
 
+    if ([string]::IsNullOrWhiteSpace($config.secrets_key_id_name)) {
+        $config.secrets_key_id_name = Read-Host "Enter Key Name for API Key ID (e.g., apikey)"
+        if ([string]::IsNullOrWhiteSpace($config.secrets_key_id_name)) {
+            throw "Key Name for API Key ID is required"
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($config.secrets_key_secret_name)) {
+        $config.secrets_key_secret_name = Read-Host "Enter Key Name for API Key Secret (e.g., apisecret)"
+        if ([string]::IsNullOrWhiteSpace($config.secrets_key_secret_name)) {
+            throw "Key Name for API Key Secret is required"
+        }
+    }
+
     $config.opa_url = $config.opa_url.TrimEnd('/')
 
     $configToSave = @{
@@ -77,6 +95,8 @@ function Initialize-OpaConfig {
         secrets_resource_group = $config.secrets_resource_group
         secrets_project = $config.secrets_project
         secrets_id = $config.secrets_id
+        secrets_key_id_name = $config.secrets_key_id_name
+        secrets_key_secret_name = $config.secrets_key_secret_name
     }
     $configToSave | ConvertTo-Json | Set-Content $script:ConfigPath -Force
 

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -31,6 +31,9 @@
 .PARAMETER ShowConfig
     Display current configuration and config file path.
 
+.PARAMETER ClearConfig
+    Delete the config file to reset all settings.
+
 .EXAMPLE
     Compare-OpaAdRotations
     Run basic comparison with default settings.
@@ -64,7 +67,9 @@ function Compare-OpaAdRotations {
 
         [switch]$Help,
 
-        [switch]$ShowConfig
+        [switch]$ShowConfig,
+
+        [switch]$ClearConfig
     )
 
     if ($Help) {
@@ -83,6 +88,7 @@ function Compare-OpaAdRotations {
         Write-Host "  -ForceRotation        Trigger rotation for mismatched accounts"
         Write-Host "  -Help                 Show this help message"
         Write-Host "  -ShowConfig           Show current configuration"
+        Write-Host "  -ClearConfig          Delete config file and reset all settings"
         Write-Host ""
         Write-Host "EXAMPLES:" -ForegroundColor Yellow
         Write-Host "  Compare-OpaAdRotations"
@@ -109,11 +115,25 @@ function Compare-OpaAdRotations {
             Write-Host "  secrets_resource_group:     $($config.secrets_resource_group)"
             Write-Host "  secrets_project:            $($config.secrets_project)"
             Write-Host "  secrets_id:                 $($config.secrets_id)"
+            Write-Host "  secrets_key_id_name:        $($config.secrets_key_id_name)"
+            Write-Host "  secrets_key_secret_name:    $($config.secrets_key_secret_name)"
         }
         else {
             Write-Host "  (config file not found - will be created on first run)" -ForegroundColor Yellow
         }
         Write-Host ""
+        return
+    }
+
+    if ($ClearConfig) {
+        $configPath = Join-Path (Split-Path $script:ModuleRoot -Parent) 'config.json'
+        if (Test-Path $configPath) {
+            Remove-Item $configPath -Force
+            Write-Host "Config file deleted: $configPath" -ForegroundColor Green
+        }
+        else {
+            Write-Host "Config file not found: $configPath" -ForegroundColor Yellow
+        }
         return
     }
 

--- a/diagnostics/AD_Pwd_Tracking/README.md
+++ b/diagnostics/AD_Pwd_Tracking/README.md
@@ -10,9 +10,17 @@ PowerShell module for verifying Okta Privileged Access (OPA) Active Directory cr
 
 - **PowerShell 7 or later** (pwsh) - Windows PowerShell 5.1 is not supported
 - Domain Controller or domain-joined server with AD PowerShell module
-- OPA Service Account API credentials (Key-ID and Key-Secret)
+- **ScaleFT Client (sft)** installed and enrolled into the OPA team
+- OPA Service Account API credentials stored in an OPA Secret
 - Read access to Security Event Log (Event IDs 4723, 4724)
 - Network access to OPA API endpoints
+
+### Credential Security
+
+This module retrieves API credentials from OPA Secrets using `sft secrets reveal`, leveraging the user's enrolled identity. Credentials are held in memory only and never written to disk. This approach:
+- Eliminates storing API keys on the server
+- Uses existing OPA enrollment for authentication
+- Supports credential rotation without reconfiguration
 
 ### OPA Service User Permissions
 
@@ -134,11 +142,13 @@ Compare-OpaAdRotations -ForceRotation
 On first run, the module prompts for:
 1. **OPA URL** - e.g., `https://myorg.pam.okta.com`
 2. **Team Name** - your OPA team identifier
-3. **Secrets Resource Group** - OPA resource group containing API credentials
-4. **Secrets Project** - OPA project containing API credentials
-5. **Secret ID** - UUID of the secret containing apikey/apisecret
+3. **Secrets Resource Group** - OPA resource group containing the API credential secret
+4. **Secrets Project** - OPA project containing the API credential secret
+5. **Secret ID** - UUID of the secret containing the API credentials
+6. **Key Name for API Key ID** - the key name in the secret for the API key ID (e.g., `apikey`)
+7. **Key Name for API Key Secret** - the key name in the secret for the API key secret (e.g., `apisecret`)
 
-Settings are stored in `config.json`.
+Settings are stored in `config.json`. Use `-ShowConfig` to view current configuration and file path.
 
 ## Additional Scripts
 


### PR DESCRIPTION
## Summary
- Add configurable key names for API credentials within OPA secret (`secrets_key_id_name`, `secrets_key_secret_name`)
- Add `-ClearConfig` option to delete config file and reset all settings
- Update README to clarify:
  - sft client must be installed and enrolled
  - Credentials retrieved via user identity, stored in memory only (never on disk)

## Test plan
- [ ] Run `Compare-OpaAdRotations -ClearConfig` to reset config
- [ ] Run `Compare-OpaAdRotations` and verify prompts for key names
- [ ] Run `Compare-OpaAdRotations -ShowConfig` to verify new fields displayed

🤖 Generated with [Claude Code](https://claude.ai/code)