### PR TITLE
Show mismatch details in summary output

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -284,8 +284,21 @@ function Compare-OpaAdRotations {
     Write-Host "$($others.Count) OTHER" -ForegroundColor Yellow
     Write-Host "Detail API calls: $detailFetchCount (only fetched for AD mismatches)" -ForegroundColor DarkGray
 
-    # Show detailed rotation info only if -ShowDetails or -ExportPath specified
-    if ($ShowDetails -or $ExportPath) {
+    # Always show mismatches in summary
+    if ($mismatches.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Mismatched Accounts:" -ForegroundColor Red
+        foreach ($mismatch in $mismatches) {
+            Write-Host "  $($mismatch.Account)" -ForegroundColor Red
+            Write-Host "    AD PasswordLastSet: $($mismatch.AdPasswordLastSet)" -ForegroundColor Yellow
+            if ($mismatch.OtherChangers) {
+                Write-Host "    Changed by: $($mismatch.OtherChangers)" -ForegroundColor Yellow
+            }
+        }
+    }
+
+    # Show detailed rotation info only if -ShowDetails specified
+    if ($ShowDetails) {
         Write-Host ""
         Write-Host "Rotation Details" -ForegroundColor Cyan
         Write-Host "================" -ForegroundColor Cyan
@@ -354,7 +367,11 @@ function Compare-OpaAdRotations {
 
     if ($ExportPath) {
         Export-RotationReport -Results $results -Path $ExportPath
+        return $results
     }
 
-    return $results
+    # Only return results if captured to a variable (not displayed to console)
+    if ($MyInvocation.Line -match '^\s*\$\w+\s*=') {
+        return $results
+    }
 }


### PR DESCRIPTION
## Summary
- Always show mismatched accounts in summary with AD PasswordLastSet timestamp and who changed it
- Suppress automatic object output (only returns when captured to variable or with -ExportPath)
- `-ShowDetails` still available for full details on all accounts

## Test plan
- [ ] Run `Compare-OpaAdRotations` - verify only summary shows, with mismatch details
- [ ] Run `$results = Compare-OpaAdRotations` - verify results captured to variable
- [ ] Run `Compare-OpaAdRotations -ShowDetails` - verify full details displayed

🤖 Generated with [Claude Code](https://claude.ai/code)