### PR TITLE
Re-add -ForceRotation with correct rotate_resource API

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Compare-OpaAdRotations.ps1
@@ -22,6 +22,9 @@
 .PARAMETER ShowDetails
     Display detailed rotation information for all accounts.
 
+.PARAMETER ForceRotation
+    Trigger password rotation for accounts with mismatches.
+
 .PARAMETER Help
     Display usage information.
 
@@ -43,6 +46,9 @@
     Compare-OpaAdRotations -ExportPath "C:\Reports\rotation-report.csv"
     Run comparison and export results to CSV.
 
+.EXAMPLE
+    Compare-OpaAdRotations -ForceRotation
+    Run comparison and trigger rotation for mismatched accounts.
 #>
 function Compare-OpaAdRotations {
     [CmdletBinding()]
@@ -56,6 +62,8 @@ function Compare-OpaAdRotations {
         [switch]$ForceTokenRefresh,
 
         [switch]$ShowDetails,
+
+        [switch]$ForceRotation,
 
         [switch]$Help,
 
@@ -77,6 +85,7 @@ function Compare-OpaAdRotations {
         Write-Host "  -LookbackDays <n>     Days to search event logs (default: from config)"
         Write-Host "  -ForceTokenRefresh    Clear cached token and re-authenticate"
         Write-Host "  -ShowDetails          Show detailed rotation info for all accounts"
+        Write-Host "  -ForceRotation        Trigger rotation for mismatched accounts"
         Write-Host "  -Help                 Show this help message"
         Write-Host "  -ShowConfig           Show current configuration"
         Write-Host "  -ClearConfig          Delete config file and reset all settings"
@@ -85,6 +94,7 @@ function Compare-OpaAdRotations {
         Write-Host "  Compare-OpaAdRotations"
         Write-Host "  Compare-OpaAdRotations -ShowDetails"
         Write-Host "  Compare-OpaAdRotations -ExportPath 'C:\Reports\report.csv'"
+        Write-Host "  Compare-OpaAdRotations -ForceRotation"
         Write-Host ""
         return
     }
@@ -256,6 +266,8 @@ function Compare-OpaAdRotations {
             RecentAdEvents = $adHistory.EventCount
             OtherChangers = ($otherChangers -join '; ')
             AdUserFound = $adHistory.AdUserFound
+            ResourceGroupId = $account.ResourceGroupId
+            ProjectId = $account.ProjectId
         }
     }
 
@@ -332,6 +344,29 @@ function Compare-OpaAdRotations {
                 if ($result.OtherChangers) {
                     Write-Host "    Non-OPA changes: $($result.OtherChangers)" -ForegroundColor Yellow
                 }
+            }
+        }
+    }
+
+    # Force rotation for mismatched accounts
+    if ($ForceRotation -and $mismatches.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Forcing Password Rotation for Mismatched Accounts" -ForegroundColor Cyan
+        Write-Host "==================================================" -ForegroundColor Cyan
+
+        foreach ($mismatch in $mismatches) {
+            Write-Host "  Rotating: $($mismatch.Account)..." -ForegroundColor Yellow -NoNewline
+            try {
+                $rotateEndpoint = "/v1/teams/$($config.team_name)/resource_groups/$($mismatch.ResourceGroupId)/projects/$($mismatch.ProjectId)/rotate_resource"
+                $rotateBody = @{
+                    resource_id = $mismatch.AccountId
+                    resource_type = 'pam_ad_account_password_login'
+                }
+                $null = Invoke-OpaApiRequest -Endpoint $rotateEndpoint -Method 'POST' -Body $rotateBody -Config $config
+                Write-Host " OK" -ForegroundColor Green
+            }
+            catch {
+                Write-Host " FAILED: $_" -ForegroundColor Red
             }
         }
     }

--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
@@ -62,6 +62,8 @@ function Get-OpaAdAccounts {
                 Id = $account.id
                 Username = if ($account.upn) { $account.upn } else { $account.username }
                 LastRotationAt = $account.last_rotation_at
+                ResourceGroupId = $account.resource_group_id
+                ProjectId = $account.project_id
             }
         }
         return $results

--- a/diagnostics/AD_Pwd_Tracking/README.md
+++ b/diagnostics/AD_Pwd_Tracking/README.md
@@ -131,6 +131,12 @@ Force token refresh (clear cached bearer token):
 Compare-OpaAdRotations -ForceTokenRefresh
 ```
 
+Trigger password rotation for mismatched accounts:
+
+```powershell
+Compare-OpaAdRotations -ForceRotation
+```
+
 ## Configuration
 
 On first run, the module prompts for:


### PR DESCRIPTION
## Summary
- Re-add `-ForceRotation` using correct API endpoint:
  `POST /v1/teams/{team}/resource_groups/{rg}/projects/{proj}/rotate_resource`
- Request body: `{ resource_id, resource_type: "pam_ad_account_password_login" }`
- Extract `resource_group_id` and `project_id` from list API response

## Test plan
- [ ] Run `Compare-OpaAdRotations -ForceRotation` with mismatched accounts

🤖 Generated with [Claude Code](https://claude.ai/code)