### PR TITLE
Fix nested resource_group.id and project.id field access

### DIFF
--- a/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
+++ b/diagnostics/AD_Pwd_Tracking/OPA-ADRotationVerifier/Public/Get-OpaAdAccounts.ps1
@@ -62,8 +62,8 @@ function Get-OpaAdAccounts {
                 Id = $account.id
                 Username = if ($account.upn) { $account.upn } else { $account.username }
                 LastRotationAt = $account.last_rotation_at
-                ResourceGroupId = $account.resource_group_id
-                ProjectId = $account.project_id
+                ResourceGroupId = $account.resource_group.id
+                ProjectId = $account.project.id
             }
         }
         return $results


### PR DESCRIPTION
## Summary
API returns nested objects (`resource_group.id`, `project.id`), not flat fields.

🤖 Generated with [Claude Code](https://claude.ai/code)